### PR TITLE
Make test name a parameter to run (functional tests)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 TEMPLATES_DIR=templates
 DISTRO=ubuntu
-
+TEST=sanity.sh
 all: helloworld stack
 
 helloworld:
@@ -16,8 +16,7 @@ stack/clearlinux stack/ubuntu:
 test:
 	m4 -I $(TEMPLATES_DIR) stack/$(DISTRO)_functest/Dockerfile.m4 | tee stack/$(DISTRO)_functest/Dockerfile
 	docker build -t stacks_$(DISTRO):test stack/$(DISTRO)_functest/
-	docker run --rm -v $(PWD)/tests:/tests stacks_$(DISTRO):test bash /tests/sanity.sh
-	docker run --rm -v $(PWD)/tests:/tests stacks_$(DISTRO):test python3 /tests/numpy_test.py
+	docker run --rm -v $(PWD)/tests:/tests stacks_$(DISTRO):test /tests/$(TEST)
 
 test_debug:
 	m4 -I $(TEMPLATES_DIR) stack/$(DISTRO)_functest/Dockerfile.m4 | tee stack/$(DISTRO)_functest/Dockerfile

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 try:
     import numpy

--- a/tests/sanity.sh
+++ b/tests/sanity.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 echo "Running Sanity"
 echo "Distro / Kernel info: "


### PR DESCRIPTION
This give the users the capability to:

```
make test TEST=numpy_test.py
make test TEST=sanity.sh
```
The script under /tests should have chmod +x and proper Shebang

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>